### PR TITLE
Add FLUX 2 Pro (flux-2-pro) support with multi-image auto-encoding

### DIFF
--- a/src/blackforest/client.py
+++ b/src/blackforest/client.py
@@ -179,16 +179,24 @@ class BFLClient:
         # Check if file exists
         return os.path.exists(value)
 
-    def _process_kontext_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Process flux-kontext-pro inputs to automatically encode image paths."""
+    def _process_multi_image_inputs(
+        self, inputs: Dict[str, Any], max_images: int = 8
+    ) -> Dict[str, Any]:
+        """
+        Process inputs with multiple image fields to automatically encode image paths.
+
+        Args:
+            inputs: Dictionary of input parameters
+            max_images: Maximum number of input images supported (default: 8)
+
+        Returns:
+            Dictionary with file paths converted to base64 encoded images
+        """
         processed_inputs = inputs.copy()
 
-        # Image fields that might need encoding
-        image_fields = [
-            "input_image",
-            "input_image_2",
-            "input_image_3",
-            "input_image_4",
+        # Build list of image fields based on max_images
+        image_fields = ["input_image"] + [
+            f"input_image_{i}" for i in range(2, max_images + 1)
         ]
 
         for field in image_fields:
@@ -411,6 +419,16 @@ class BFLClient:
                                         {"prompt": "a beautiful forest"}, \
                                         config)
             >>> print(f"Image URL: {response.result.sample}")
+            >>>
+            >>> # FLUX 2 Pro with multiple input images (auto-encoding)
+            >>> response = client.generate("flux-2-pro", {
+            ...     "prompt": "combine these images",
+            ...     "input_image": "path/to/image1.jpg",
+            ...     "input_image_2": "path/to/image2.jpg",
+            ...     "width": 1024,
+            ...     "height": 768
+            ... })
+            >>> print(f"Task ID: {response.id}")
         """
         if config is None:
             config = ClientConfig()
@@ -423,10 +441,14 @@ class BFLClient:
                            Supported models: {list(self.model_input_registry.keys())}"
             )
 
-        # Process inputs for automatic image encoding if using flux-kontext-pro
+        # Process inputs for automatic image encoding for models with multiple image support
         processed_inputs = inputs
         if model == "flux-kontext-pro":
-            processed_inputs = self._process_kontext_inputs(inputs)
+            # flux-kontext-pro supports up to 4 input images
+            processed_inputs = self._process_multi_image_inputs(inputs, max_images=4)
+        elif model == "flux-2-pro":
+            # flux-2-pro supports up to 8 input images
+            processed_inputs = self._process_multi_image_inputs(inputs, max_images=8)
 
         # Convert the inputs to the appropriate type
         typed_inputs = input_cls(**processed_inputs)

--- a/src/blackforest/resources/mapping/model_input_registry.py
+++ b/src/blackforest/resources/mapping/model_input_registry.py
@@ -2,6 +2,7 @@ from blackforest.types.inputs.flux_dev import FluxDevInputs
 from blackforest.types.inputs.flux_kontext_pro import FluxKontextProInputs
 from blackforest.types.inputs.flux_pro import FluxProInputs
 from blackforest.types.inputs.flux_pro_1_1 import FluxPro11Inputs
+from blackforest.types.inputs.flux_pro_2 import FluxPro2Inputs
 from blackforest.types.inputs.flux_pro_canny import FluxProCannyInputs
 from blackforest.types.inputs.flux_pro_depth import FluxProDepthInputs
 from blackforest.types.inputs.flux_pro_expand import FluxProExpandInputs
@@ -18,4 +19,5 @@ MODEL_INPUT_REGISTRY = {
     "flux-pro-1.0-canny": FluxProCannyInputs,
     "flux-pro-1.0-depth": FluxProDepthInputs,
     "flux-kontext-pro": FluxKontextProInputs,
+    "flux-2-pro": FluxPro2Inputs
 }

--- a/src/blackforest/types/inputs/flux_pro_2.py
+++ b/src/blackforest/types/inputs/flux_pro_2.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+from pydantic import Field
+
+from blackforest.types.inputs.generic import GenericImageInput
+
+
+class FluxPro2Inputs(GenericImageInput):
+    """Inputs for the Flux Pro 2.0 model.
+
+    Supports multiple input images (up to 8) and flexible dimensions.
+    """
+
+    # Multiple input image support
+    input_image: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded input image",
+    )
+    input_image_2: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded second input image",
+    )
+    input_image_3: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded third input image",
+    )
+    input_image_4: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded fourth input image",
+    )
+    input_image_5: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded fifth input image",
+    )
+    input_image_6: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded sixth input image",
+    )
+    input_image_7: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded seventh input image",
+    )
+    input_image_8: Optional[str] = Field(
+        default=None,
+        description="Base64 encoded eighth input image",
+    )
+
+    # Dimension parameters with FLUX2 Pro constraints
+    width: Optional[int] = Field(
+        default=None,
+        ge=64,
+        multiple_of=16,
+        description="Width of the generated image in pixels. Must be at least 64 and a multiple of 16.",
+    )
+    height: Optional[int] = Field(
+        default=None,
+        ge=64,
+        multiple_of=16,
+        description="Height of the generated image in pixels. Must be at least 64 and a multiple of 16.",
+    )
+
+    # Override safety_tolerance range for FLUX2 Pro (0-5 instead of 0-6)
+    safety_tolerance: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        description="Tolerance level for input and output moderation. "
+        "Between 0 and 5, 0 being most strict, 5 being least strict.",
+        example=2,
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -318,3 +318,34 @@ def test_generate_flux_kontext_pro_model(model, sync):
         assert response.result is not None
     else:
         assert response.id is not None
+
+
+@pytest.mark.parametrize("model", ["flux-2-pro"])
+@pytest.mark.parametrize("sync", [False, True])
+def test_generate_flux_2_pro_model(model, sync):
+    print(f"Using API key: {BFL_API_KEY}")
+    client = BFLClient(api_key=BFL_API_KEY)
+
+    inputs = {
+        "prompt": "A beautiful landscape combining elements from the input images",
+        "input_image": "tests/inputs/test_image_1.jpeg",
+        "input_image_2": "tests/inputs/test_image_2.jpeg",
+        "width": 1024,
+        "height": 768,
+        "output_format": "png",
+        "seed": 42,
+        "safety_tolerance": 2,
+        "prompt_upsampling": True,
+    }
+
+    config = ClientConfig(sync=sync)
+
+    # Call generate with dictionary and config
+    response = client.generate(model, inputs, config)
+    print(f"Response: {response}")
+
+    if sync:
+        assert response.id is not None
+        assert response.result is not None
+    else:
+        assert response.id is not None


### PR DESCRIPTION
- Create FluxPro2Inputs class supporting up to 8 input images
- Refactor _process_kontext_inputs to _process_multi_image_inputs for reusability
- Add automatic file path encoding for flux-2-pro model
- Register flux-2-pro endpoint in model registry
- Add comprehensive tests for async and sync modes
- Update documentation with usage examples